### PR TITLE
`widget: none` hides fields, not `widget: hidden`

### DIFF
--- a/semantics.json
+++ b/semantics.json
@@ -18,27 +18,27 @@
             {
               "name": "id",
               "type": "text",
-              "widget": "hidden"
+              "widget": "none"
             },
             {
               "name": "xPercentagePosition",
               "type": "number",
-              "widget": "hidden"
+              "widget": "none"
             },
             {
               "name": "yPercentagePosition",
               "type": "number",
-              "widget": "hidden"
+              "widget": "none"
             },
             {
               "name": "widthPercentage",
               "type": "number",
-              "widget": "hidden"
+              "widget": "none"
             },
             {
               "name": "heightPercentage",
               "type": "number",
-              "widget": "hidden"
+              "widget": "none"
             },
             {
               "label": "Label",


### PR DESCRIPTION
We hide fields that shouldn't be changed directly by the user