### PR TITLE
fallback alt text for topic map item images

### DIFF
--- a/src/components/TopicMapItem/TopicMapItem.tsx
+++ b/src/components/TopicMapItem/TopicMapItem.tsx
@@ -19,7 +19,7 @@ export const TopicMapItem: React.FC<TopicMapItemProps> = ({
         <img
           className={styles.bgImage}
           src={backgroundImage.path}
-          alt={backgroundImage.alt}
+          alt={backgroundImage.alt ?? ""}
         />
       )}
       <div className={styles.title}>{title}</div>


### PR DESCRIPTION
If `backgroundImage.alt` is set to `null`, then the `alt` attribute would
not be rendered at all.