### PR TITLE
use `>=` to check whether the max word count has been reached

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.TopicMap",
   "majorVersion": 0,
   "minorVersion": 1,
-  "patchVersion": 56,
+  "patchVersion": 57,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/src/components/Dialog-Window/Notes/DialogNote.tsx
+++ b/src/components/Dialog-Window/Notes/DialogNote.tsx
@@ -53,7 +53,10 @@ export const DialogNote: React.FC<NoteProps> = ({ maxLength, id }) => {
     const count = note.split(/\s/).filter(word => word.length > 0).length;
     setWordCount(count);
 
-    if (count === maxLength && note[note.length - 1] === " ") {
+    // TODO: Enforce max length when pasting in text,
+    // perhaps by removing all words past the max length mark.
+    const tooManyWords = count >= maxLength && note[note.length - 1] === " ";
+    if (tooManyWords) {
       setMaxWordCount(count);
     } else {
       setMaxWordCount(undefined);


### PR DESCRIPTION
If the user reaches past the limit when pasting text, the maxLength is
surpassed, thus letting the user type even more, as it's now no longer
exactly as many words as the limit.