### PR TITLE
Move white font color to help section

### DIFF
--- a/src/components/Navbar/HelpSection/HelpSection.module.scss
+++ b/src/components/Navbar/HelpSection/HelpSection.module.scss
@@ -25,6 +25,7 @@
 
 .mainBodyText {
   margin-top: 0.5rem;
+  color: #ffffff;
 }
 
 @media (min-width: 768px) {

--- a/src/components/Navbar/Navbar.module.scss
+++ b/src/components/Navbar/Navbar.module.scss
@@ -44,7 +44,6 @@ $grid-z-index: 1;
 .sectionContent {
   width: 100%;
   padding-top: 1.5rem;
-  color: #ffffff;
 }
 
 .sectionsMenu,


### PR DESCRIPTION
Avoid adding the white color to the dialog text, and just add it to the help section