### PR TITLE
Remove position absolute from contentWrapper

### DIFF
--- a/src/components/Navbar/HelpSection/HelpSection.module.scss
+++ b/src/components/Navbar/HelpSection/HelpSection.module.scss
@@ -5,7 +5,7 @@
   background-color: var(--theme-color-2);
   height: 100%;
   width: 100%;
-  padding: 2rem 0 0;
+  padding: 1rem 0 2rem;
 
   p {
     color: #ffffff;

--- a/src/components/Navbar/Navbar.module.scss
+++ b/src/components/Navbar/Navbar.module.scss
@@ -2,7 +2,6 @@ $navbar-height: 2.52rem;
 $grid-z-index: 1;
 
 .contentWrapper {
-  position: absolute;
   width: 100%;
 }
 


### PR DESCRIPTION
Keep content within h5p frame. When removing the background colors, you can see that the placement of the content is not relative to other elements and overlaps them. 


<img width="722" alt="Skjermbilde 2022-02-22 kl  16 33 28" src="https://user-images.githubusercontent.com/35261194/155166050-0eb31993-3096-4b79-80e5-31c533bbabc9.png">
