### PR TITLE
Hide notes label on small screens

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.TopicMap",
   "majorVersion": 0,
   "minorVersion": 1,
-  "patchVersion": 62,
+  "patchVersion": 63,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/src/components/Dialog-Window/Notes/DialogNote.module.scss
+++ b/src/components/Dialog-Window/Notes/DialogNote.module.scss
@@ -34,8 +34,10 @@ form {
 }
 
 .dynamicSavingText {
-  margin-block-start: 0.8rem;
+  line-height: 1.2;
+  margin-block-start: 0;
   margin-block-end: 0.2rem;
+  min-height: 1.2rem; // Should be equal to line-height
   order: 1;
 }
 
@@ -72,6 +74,7 @@ form {
 }
 
 .noteLabel {
+  line-height: 1.2;
   margin-block-start: 0.8rem;
   margin-block-end: 0.2rem;
   font-weight: 700;

--- a/src/components/Dialog-Window/Notes/DialogNote.module.scss
+++ b/src/components/Dialog-Window/Notes/DialogNote.module.scss
@@ -34,9 +34,9 @@ form {
 }
 
 .dynamicSavingText {
-  position: absolute;
-  top: -1rem;
-  right: 0;
+  margin-block-start: 0.8rem;
+  margin-block-end: 0.2rem;
+  order: 1;
 }
 
 .markAsCompletedCheckbox {
@@ -49,6 +49,14 @@ form {
     position: relative;
     top: 0.25rem;
   }
+}
+
+.topGroup {
+  align-items: flex-end;
+  display: flex;
+  flex-direction: row-reverse;
+  flex-wrap: wrap;
+  justify-content: space-between;
 }
 
 .bottomGroup {
@@ -67,4 +75,5 @@ form {
   margin-block-start: 0.8rem;
   margin-block-end: 0.2rem;
   font-weight: 700;
+  order: 2;
 }

--- a/src/components/Dialog-Window/Notes/DialogNote.tsx
+++ b/src/components/Dialog-Window/Notes/DialogNote.tsx
@@ -8,12 +8,14 @@ export type NoteProps = {
   maxLength: number;
   id: string;
   setUserDataCopy?: React.Dispatch<React.SetStateAction<UserData>>;
+  smallScreen?: boolean;
 };
 
 export const DialogNote: React.FC<NoteProps> = ({
   maxLength,
   id,
   setUserDataCopy,
+  smallScreen,
 }) => {
   const [userData, setUserData] = useLocalStorage(id);
   const [note, setNote] = React.useState(userData[id].note ?? "");
@@ -90,8 +92,10 @@ export const DialogNote: React.FC<NoteProps> = ({
   return (
     <form>
       <label htmlFor="note">
-        <p className={styles.noteLabel}>{wordNoteLabel}</p>
-        <p className={styles.dynamicSavingText}>{dynamicSavingText}</p>
+        <div className={styles.topGroup}>
+          {!smallScreen && <p className={styles.noteLabel}>{wordNoteLabel}</p>}
+          <p className={styles.dynamicSavingText}>{dynamicSavingText}</p>
+        </div>
         <div className={styles.textAreaWrapper}>
           <textarea
             className={styles.textArea}

--- a/src/components/Dialog-Window/Tabs/DialogTabs.tsx
+++ b/src/components/Dialog-Window/Tabs/DialogTabs.tsx
@@ -153,7 +153,7 @@ export const DialogTabs: React.FC<TabProps> = ({ item }) => {
         {tabItems(item)}
         {smallScreen ? (
           <Content key="notes" value="notes" className={styles.noteWrapper}>
-            <DialogNote maxLength={160} id={item.id} />
+            <DialogNote maxLength={160} id={item.id} smallScreen />
           </Content>
         ) : null}
       </div>


### PR DESCRIPTION
Suggestion to only show one "Note" label on smaller screens. Now, on smaller screens the "Note" label is also visible in the tabs, so we don't need to show the "Notes" label in the DialogNote component as well. 

<img width="445" alt="Skjermbilde 2022-02-23 kl  10 01 56" src="https://user-images.githubusercontent.com/35261194/155315306-499b5cd7-2342-470c-b450-8138d2dfa7f5.png">
