### PR TITLE
Add tags to semantics for help section

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.TopicMap",
   "majorVersion": 0,
   "minorVersion": 1,
-  "patchVersion": 66,
+  "patchVersion": 67,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/semantics.json
+++ b/semantics.json
@@ -493,8 +493,15 @@
         "label": "Navbar help section body",
         "name": "navbarHelpSectionBody",
         "widget": "html",
-        "default": "<p>The purpose of this exercise is to enhance your learning by linking your own notes to a topic map. The topic map consists of events (boxes) and connections (arrows). You must enter notes for both events and connections.</p><br /><p>Click or tap the boxes and arrows to add a note to an event or connection. The notes you enter are automatically saved locally in the browser of the device you are using, so you can continue on or read the notes at a later time.</p><br /><p><strong>Progress bar</strong> shows what percentage of the events and connections have received notes. 100% means you have posted notes in all available places.</p><br /><p><strong>Export the notes</strong> gives you an overview of all the notes you have written. There you can print or copy the notes to e.g. paste them into a document or email.</p><br /><p><strong>Delete all notes</strong> removes all notes from the browser on the device you are using.</p>",
-        "type": "text"
+        "default": "<p>The purpose of this exercise is to enhance your learning by linking your own notes to a topic map. The topic map consists of events (boxes) and connections (arrows). You must enter notes for both events and connections.</p><br /><p>Click or tap the boxes and arrows to add a note to an event or connection. The notes you enter are automatically saved locally in the browser of the device you are using, so you can continue on or read the notes at a later time.</p><br /><p><strong>Progress bar</strong> shows what percentage of the events and connections have received notes. 100% means you have posted notes in all available places.</p><br /><p><strong>See notes</strong> gives you an overview of all the notes you have written. There you can print out the notes or delete all the notes.</p>",
+        "type": "text",
+        "tags": [
+          "p",
+          "br",
+          "strong",
+          "em",
+          "a"
+        ]
       },
       {
         "label": "Dialog resources labels",

--- a/src/semantics.ts
+++ b/src/semantics.ts
@@ -336,8 +336,9 @@ export const semantics: Readonly<[H5PFieldGroup, H5PBehaviour, H5PL10n]> = [
         name: "navbarHelpSectionBody",
         widget: "html",
         default:
-          "<p>The purpose of this exercise is to enhance your learning by linking your own notes to a topic map. The topic map consists of events (boxes) and connections (arrows). You must enter notes for both events and connections.</p><br /><p>Click or tap the boxes and arrows to add a note to an event or connection. The notes you enter are automatically saved locally in the browser of the device you are using, so you can continue on or read the notes at a later time.</p><br /><p><strong>Progress bar</strong> shows what percentage of the events and connections have received notes. 100% means you have posted notes in all available places.</p><br /><p><strong>Export the notes</strong> gives you an overview of all the notes you have written. There you can print or copy the notes to e.g. paste them into a document or email.</p><br /><p><strong>Delete all notes</strong> removes all notes from the browser on the device you are using.</p>",
+          "<p>The purpose of this exercise is to enhance your learning by linking your own notes to a topic map. The topic map consists of events (boxes) and connections (arrows). You must enter notes for both events and connections.</p><br /><p>Click or tap the boxes and arrows to add a note to an event or connection. The notes you enter are automatically saved locally in the browser of the device you are using, so you can continue on or read the notes at a later time.</p><br /><p><strong>Progress bar</strong> shows what percentage of the events and connections have received notes. 100% means you have posted notes in all available places.</p><br /><p><strong>See notes</strong> gives you an overview of all the notes you have written. There you can print out the notes or delete all the notes.</p>",
         type: H5PFieldType.Text,
+        tags: ["p", "br", "strong", "em", "a"],
       },
       {
         label: "Dialog resources labels",


### PR DESCRIPTION
Did also change the text a bit since we moved the print and delete notes under "See notes". This change will not update topic maps that are already created! The new text must be copied and pasted into those topic maps. 