### PR TITLE
Hide tab section when no tab content

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.TopicMap",
   "majorVersion": 0,
   "minorVersion": 1,
-  "patchVersion": 69,
+  "patchVersion": 70,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/src/components/Dialog-Window/DialogWindow.module.scss
+++ b/src/components/Dialog-Window/DialogWindow.module.scss
@@ -21,7 +21,7 @@
 }
 
 .dialogContent,
-.dialogContentWithNote {
+.dialogContentWide {
   background-color: white;
   border-radius: 6px;
   position: fixed;
@@ -39,7 +39,7 @@
   width: 40vw;
 }
 
-.dialogContentWithNote {
+.dialogContentWide {
   width: 70vw;
 }
 
@@ -53,10 +53,15 @@
   float: right;
   width: 47%;
   height: 80%;
+
+  &.fullWidth {
+    float: left;
+    width: 100%;
+  }
 }
 
 .dialogContent:focus,
-.dialogContentWithNote:focus {
+.dialogContentWide:focus {
   outline: none;
 }
 

--- a/src/components/Dialog-Window/DialogWindow.tsx
+++ b/src/components/Dialog-Window/DialogWindow.tsx
@@ -71,8 +71,16 @@ export const DialogWindow: FC<DialogWindowProps> = ({
     return null;
   }
 
+  const noTabItems =
+    !item.description &&
+    !item.topicImage &&
+    !item.dialog.audio?.audioFile &&
+    !item.dialog.links &&
+    !item.dialog.text &&
+    !item.dialog.video;
+
   let content = smallScreen ? (
-    <Content className={styles.dialogContentWithNote}>
+    <Content className={styles.dialogContentWide}>
       <Title className={styles.dialogTitle}>{item.label}</Title>
       <DialogTabs
         item={item}
@@ -90,11 +98,13 @@ export const DialogWindow: FC<DialogWindowProps> = ({
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: item.label }}
       />
-      <DialogTabs
-        item={item}
-        userDataCopy={userDataCopy}
-        setUserDataCopy={setUserDataCopy}
-      />
+      {!noTabItems && (
+        <DialogTabs
+          item={item}
+          userDataCopy={userDataCopy}
+          setUserDataCopy={setUserDataCopy}
+        />
+      )}
       <Close className={styles.closeButton} aria-label={ariaLabel}>
         <Cross2Icon />
       </Close>
@@ -103,20 +113,28 @@ export const DialogWindow: FC<DialogWindowProps> = ({
 
   if (item.dialog.hasNote && !smallScreen) {
     content = (
-      <Content className={styles.dialogContentWithNote}>
+      <Content
+        className={noTabItems ? styles.dialogContent : styles.dialogContentWide}
+      >
         <Title
           className={styles.dialogTitle}
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: item.label }}
         />
-        <div className={styles.tabWrapper}>
-          <DialogTabs
-            item={item}
-            userDataCopy={userDataCopy}
-            setUserDataCopy={setUserDataCopy}
-          />
-        </div>
-        <div className={styles.noteWrapper}>
+        {!noTabItems && (
+          <div className={styles.tabWrapper}>
+            <DialogTabs
+              item={item}
+              userDataCopy={userDataCopy}
+              setUserDataCopy={setUserDataCopy}
+            />
+          </div>
+        )}
+        <div
+          className={`${styles.noteWrapper} ${
+            noTabItems ? styles.fullWidth : ""
+          }`}
+        >
           <DialogNote
             maxLength={item.dialog.maxWordCount ?? 160}
             id={item.id}

--- a/src/components/Dialog-Window/Tabs/DialogTabs.tsx
+++ b/src/components/Dialog-Window/Tabs/DialogTabs.tsx
@@ -142,6 +142,8 @@ export const DialogTabs: React.FC<TabProps> = ({
   const noteLabel = useL10n("dialogNoteLabel");
   const smallScreen = useMedia("(max-width: 768px)");
 
+  const hasNote = item.dialog?.hasNote;
+
   return (
     <Root
       className={styles.tabs}
@@ -150,7 +152,7 @@ export const DialogTabs: React.FC<TabProps> = ({
     >
       <List className={styles.list} aria-label={listAriaLabel}>
         {tabLabelItems(item, translation)}
-        {smallScreen ? (
+        {smallScreen && hasNote ? (
           <Trigger key="notes" className={styles.trigger} value="notes">
             {noteLabel}
           </Trigger>
@@ -158,7 +160,7 @@ export const DialogTabs: React.FC<TabProps> = ({
       </List>
       <div className={styles.tabItemWrapper}>
         {tabItems(item)}
-        {smallScreen ? (
+        {smallScreen && hasNote ? (
           <Content key="notes" value="notes" className={styles.noteWrapper}>
             <DialogNote
               maxLength={item.dialog?.maxWordCount ?? 160}


### PR DESCRIPTION
Hide the tab section in the dialog when there is nothing to show. If there is a note section then make it fill the dialog. 

Hides this left section: 
<img width="703" alt="Skjermbilde 2022-02-28 kl  11 24 57" src="https://user-images.githubusercontent.com/35261194/155967967-9e570cbd-00f2-40fc-93e5-c0fc0a028b16.png">
