### PR TITLE
Avoid tab labels overlapping note label

### DIFF
--- a/src/components/App/App.stories.tsx
+++ b/src/components/App/App.stories.tsx
@@ -198,7 +198,34 @@ DenFranskeRevolusjon.args = {
           dialog: {
             hasNote: true,
             maxWordCount: 300,
-            audio: {},
+            audio: {
+              audioFile: [
+                { path: "https://bigsoundbank.com/UPLOAD/mp3/0001.mp3" },
+              ],
+              subtext: `
+                <b>
+                  Den franske revolusjon var en periode med store sosiale og politiske
+                  omveltningene i Frankrike i perioden 1789-1799. Året 1789 markerer det
+                  første viktige vendepunktet under revolusjonen. 14. juli dette året brøt
+                  det ut masseopprør i Paris og fengselet Bastillen ble stormet.
+                </b>
+                <br />
+                <p>
+                  Perioden 1787-1789 kalles gjerne førrevolusjonen, men langsiktige
+                  årsaker til revolusjonen strekker seg naturligvis mye lenger tilbake i
+                  tid. De viktigste politiske, sosiale og administrative omveltninger
+                  skjedde i perioden 1789-1794.
+                </p>
+            `,
+            },
+            links: ["wwww.ndla.no"],
+            video: [
+              {
+                path: "https://www.youtube.com/watch?v=zHvBPwNUBS8",
+                mime: "video/YouTube",
+                copyright: { license: "U" },
+              },
+            ],
             text: `Perioden 1787–1789 kalles gjerne før-revolusjonen, men langsiktige årsaker til revolusjonen strekker seg naturligvis mye lenger tilbake i tid. De viktigste politiske, sosiale og administrative omveltninger skjedde i perioden 1789–1794. Deretter fulgte en periode hvor mange av de mest radikale tiltak fra tidligere ble moderert eller reversert, men hvor myndighetene mislyktes i å oppnå stabilitet og legitimitet. Med Napoleon Bonapartes statskupp i 1799 fikk Frankrike igjen et stabilt styre, til prisen av den politiske frihet.`,
           },
           topicImage: {

--- a/src/components/Dialog-Window/Tabs/DialogTabs.module.scss
+++ b/src/components/Dialog-Window/Tabs/DialogTabs.module.scss
@@ -14,10 +14,11 @@
   user-select: none;
   cursor: pointer;
   max-width: min-content;
+  border-bottom: 2px solid #eee;
 
   &[data-state="active"] {
     font-weight: 800;
-    box-shadow: 0 2.5px 0 -0.5px #2360c5;
+    border-bottom: 2px solid #2360c5;
   }
 
   &:focus {
@@ -28,8 +29,9 @@
 .list {
   flex-shrink: 0;
   display: flex;
-  border-bottom: 2px solid #eee;
+  box-shadow: inset 0 -2px 0 #eee;
   margin-bottom: 1rem;
+  overflow-x: auto;
 }
 
 .tabs {


### PR DESCRIPTION
When tabs have many items it will overlap the note label on some screen sizes. This change will make the overflow of the tabs appear in a scroll instead of overlapping the note label.

<img width="604" alt="Skjermbilde 2022-02-28 kl  12 37 39" src="https://user-images.githubusercontent.com/35261194/156016923-e5583db5-345d-475e-af0f-14a07165d089.png">
