### PR TITLE
Unset max-height of notesList on print

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.TopicMap",
   "majorVersion": 0,
   "minorVersion": 1,
-  "patchVersion": 99,
+  "patchVersion": 100,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/src/components/Navbar/Navbar.module.scss
+++ b/src/components/Navbar/Navbar.module.scss
@@ -60,6 +60,10 @@ $grid-z-index: 1;
 .notesList {
   background-color: #ffffff;
   overflow-y: auto;
+
+  @media print {
+    max-height: unset !important;
+  }
 }
 
 .hamburgerButton {


### PR DESCRIPTION
NotesList still used the max-height value on print, so only the content above the max-height was shown, and a scrollbar was visible in the document. This PR unsets the max-height value. 