### PR TITLE
fix: amend .h5pignore

### DIFF
--- a/.h5pignore
+++ b/.h5pignore
@@ -3,7 +3,12 @@ src
 .babelrc
 .gitignore
 .h5pignore
+.storybook
 package.json
 package-lock.json
 README.md
 vite.config.ts
+babel.config.js
+tsconfig.json
+nodemon.json
+storybook-static


### PR DESCRIPTION
Currently, .h5pignore doesn't cover a couple of files that the H5P CLI tool should not pack into H5P libraries.

When merged in, .h5pignore will cover a couple all files that the H5P CLI tool should not pack into H5P libraries.