### PR TITLE
Remove resize observer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@radix-ui/react-icons": "^1.1.0",
         "@radix-ui/react-tabs": "^0.1.5",
         "@ramonak/react-progress-bar": "^4.4.0",
-        "@react-hook/resize-observer": "^1.2.5",
         "is-ios": "^2.1.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -3690,11 +3689,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@juggle/resize-observer": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.3.1.tgz",
-      "integrity": "sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw=="
-    },
     "node_modules/@mdx-js/loader": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-1.6.22.tgz",
@@ -4276,37 +4270,6 @@
       "peerDependencies": {
         "react": "^16.0.0 || ^17",
         "react-dom": "^16.0.0 || ^17"
-      }
-    },
-    "node_modules/@react-hook/latest": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
-      "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==",
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/@react-hook/passive-layout-effect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
-      "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==",
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/@react-hook/resize-observer": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@react-hook/resize-observer/-/resize-observer-1.2.5.tgz",
-      "integrity": "sha512-qa0pPvRxq5VbdI8mMK2apPFsZOckhQ6D3Jc9yLuyHMNhui8yEih4qyFCZBDzzK3ymZS6LAltVSVg3l1Dg9vA0w==",
-      "dependencies": {
-        "@juggle/resize-observer": "^3.3.1",
-        "@react-hook/latest": "^1.0.2",
-        "@react-hook/passive-layout-effect": "^1.2.0",
-        "@types/raf-schd": "^4.0.0",
-        "raf-schd": "^4.0.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -11036,11 +10999,6 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
-    },
-    "node_modules/@types/raf-schd": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/raf-schd/-/raf-schd-4.0.1.tgz",
-      "integrity": "sha512-Ha+EnKHFIh9EKW0/XZJPUd3EGDFisEvauaBd4VVCRPKeOqUxNEc9TodiY2Zhk33XCgzJucoFEcaoNcBAPHTQ2A=="
     },
     "node_modules/@types/react": {
       "version": "17.0.44",
@@ -25788,11 +25746,6 @@
         }
       ]
     },
-    "node_modules/raf-schd": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
-      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
-    },
     "node_modules/ramda": {
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
@@ -34022,11 +33975,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "@juggle/resize-observer": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.3.1.tgz",
-      "integrity": "sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw=="
-    },
     "@mdx-js/loader": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-1.6.22.tgz",
@@ -34460,30 +34408,6 @@
       "resolved": "https://registry.npmjs.org/@ramonak/react-progress-bar/-/react-progress-bar-4.4.0.tgz",
       "integrity": "sha512-/djk0ZzQZXd2x6uMJ1YL5EeFBN1uJQVFcV5NrP1B29m31LL6xb5ahbpz255m3bFY3ZHpI7awE6L4SlfBW4mDWw==",
       "requires": {}
-    },
-    "@react-hook/latest": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
-      "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==",
-      "requires": {}
-    },
-    "@react-hook/passive-layout-effect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
-      "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==",
-      "requires": {}
-    },
-    "@react-hook/resize-observer": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@react-hook/resize-observer/-/resize-observer-1.2.5.tgz",
-      "integrity": "sha512-qa0pPvRxq5VbdI8mMK2apPFsZOckhQ6D3Jc9yLuyHMNhui8yEih4qyFCZBDzzK3ymZS6LAltVSVg3l1Dg9vA0w==",
-      "requires": {
-        "@juggle/resize-observer": "^3.3.1",
-        "@react-hook/latest": "^1.0.2",
-        "@react-hook/passive-layout-effect": "^1.2.0",
-        "@types/raf-schd": "^4.0.0",
-        "raf-schd": "^4.0.2"
-      }
     },
     "@rollup/pluginutils": {
       "version": "4.2.1",
@@ -39743,11 +39667,6 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
-    },
-    "@types/raf-schd": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/raf-schd/-/raf-schd-4.0.1.tgz",
-      "integrity": "sha512-Ha+EnKHFIh9EKW0/XZJPUd3EGDFisEvauaBd4VVCRPKeOqUxNEc9TodiY2Zhk33XCgzJucoFEcaoNcBAPHTQ2A=="
     },
     "@types/react": {
       "version": "17.0.44",
@@ -51176,11 +51095,6 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
-    },
-    "raf-schd": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
-      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
     },
     "ramda": {
       "version": "0.21.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@radix-ui/react-icons": "^1.1.0",
     "@radix-ui/react-tabs": "^0.1.5",
     "@ramonak/react-progress-bar": "^4.4.0",
-    "@react-hook/resize-observer": "^1.2.5",
     "is-ios": "^2.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -78,7 +78,6 @@ export const App: React.FC<AppProps> = ({
               <Navbar
                 navbarTitle={title ?? ""}
                 params={params}
-                fullscreenHandle={fullscreenHandle}
                 toggleIPhoneFullscreen={handleToggleIPhoneFullscreen}
                 isIPhoneFullscreenActive={isIPhoneFullscreenActive}
                 instance={instance}

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -48,7 +48,7 @@ export const App: React.FC<AppProps> = ({
    * React supplies useResizeObserver hook, but H5P may trigger `resize` not
    * only when the window resizes
    */
-  instance.on('resize', () => {
+  instance.on("resize", () => {
     window.requestAnimationFrame(() => {
       if (!containerRef.current) {
         return;

--- a/src/components/FullscreenButton/FullscreenButton.tsx
+++ b/src/components/FullscreenButton/FullscreenButton.tsx
@@ -19,8 +19,7 @@ export const FullscreenButton: React.FC<FullscreenButtonProps> = ({
   const handleFullscreen = (): void => {
     if (isIOS) {
       toggleIOSFullscreen();
-    }
-    else {
+    } else {
       setTimeout(() => {
         if (!h5pInstance) {
           return;

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { FullScreenHandle } from "react-full-screen";
 
 import { Grid, GridProps } from "./Grid";
 import { ArrowType } from "../../types/ArrowType";
@@ -15,7 +14,6 @@ const defaultArgs: GridProps = {
   items: [],
   arrowItems: [],
   backgroundImage: undefined,
-  fullscreenHandle: {} as FullScreenHandle,
 };
 
 export const WithItems: ComponentStory<typeof Grid> = () => {

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -1,7 +1,6 @@
 import type { Image } from "h5p-types";
 import * as React from "react";
 import { useState } from "react";
-import { FullScreenHandle } from "react-full-screen";
 import { ArrowItemType } from "../../types/ArrowItemType";
 import { CommonItemType } from "../../types/CommonItemType";
 import { TopicMapItemType } from "../../types/TopicMapItemType";
@@ -16,7 +15,6 @@ export type GridProps = {
   arrowItems: Array<ArrowItemType>;
   backgroundImage: Image | undefined;
   grid?: GridDimensions;
-  fullscreenHandle: FullScreenHandle;
 };
 
 export type GridDimensions = {
@@ -29,7 +27,6 @@ export const Grid: React.FC<GridProps> = ({
   arrowItems,
   backgroundImage,
   grid,
-  fullscreenHandle,
 }) => {
   const gridContainerRef = React.createRef<HTMLDivElement>();
   const [itemShowingDialog, setItemShowingDialog] =
@@ -173,7 +170,7 @@ export const Grid: React.FC<GridProps> = ({
       ]
         .filter(Boolean)
         .join(" "),
-    [H5P.isFullscreen],
+    [],
   );
 
   return (

--- a/src/components/Navbar/Navbar.stories.tsx
+++ b/src/components/Navbar/Navbar.stories.tsx
@@ -1,6 +1,7 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import * as React from "react";
 import { FullScreenHandle } from "react-full-screen";
+import type { IH5PContentType } from "h5p-types";
 import { Navbar, NavbarProps } from "./Navbar";
 
 export default {
@@ -14,6 +15,7 @@ const defaultArgs: NavbarProps = {
   fullscreenHandle: {} as FullScreenHandle,
   toggleIPhoneFullscreen: () => null,
   isIPhoneFullscreenActive: false,
+  instance: {} as IH5PContentType
 };
 
 export const NavBar: ComponentStory<typeof Navbar> = () => {

--- a/src/components/Navbar/Navbar.stories.tsx
+++ b/src/components/Navbar/Navbar.stories.tsx
@@ -1,6 +1,5 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import * as React from "react";
-import { FullScreenHandle } from "react-full-screen";
 import type { IH5PContentType } from "h5p-types";
 import { Navbar, NavbarProps } from "./Navbar";
 
@@ -12,7 +11,6 @@ export default {
 const defaultArgs: NavbarProps = {
   navbarTitle: "National romanticism",
   params: {},
-  fullscreenHandle: {} as FullScreenHandle,
   toggleIPhoneFullscreen: () => null,
   isIPhoneFullscreenActive: false,
   instance: {} as IH5PContentType,

--- a/src/components/Navbar/Navbar.stories.tsx
+++ b/src/components/Navbar/Navbar.stories.tsx
@@ -15,7 +15,7 @@ const defaultArgs: NavbarProps = {
   fullscreenHandle: {} as FullScreenHandle,
   toggleIPhoneFullscreen: () => null,
   isIPhoneFullscreenActive: false,
-  instance: {} as IH5PContentType
+  instance: {} as IH5PContentType,
 };
 
 export const NavBar: ComponentStory<typeof Navbar> = () => {

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,7 +1,6 @@
 import ProgressBar from "@ramonak/react-progress-bar";
 import * as React from "react";
 import { useState } from "react";
-import type { FullScreenHandle } from "react-full-screen";
 import { useReactToPrint } from "react-to-print";
 import type { IH5PContentType } from "h5p-types";
 import { useContentId } from "../../hooks/useContentId";
@@ -26,7 +25,6 @@ import { H5P } from "../../h5p/H5P.util";
 export type NavbarProps = {
   navbarTitle: string;
   params: Params;
-  fullscreenHandle: FullScreenHandle;
   toggleIPhoneFullscreen: () => void;
   isIPhoneFullscreenActive: boolean;
   instance: IH5PContentType;
@@ -35,7 +33,6 @@ export type NavbarProps = {
 export const Navbar: React.FC<NavbarProps> = ({
   navbarTitle,
   params,
-  fullscreenHandle,
   toggleIPhoneFullscreen,
   isIPhoneFullscreenActive,
   instance,
@@ -385,7 +382,6 @@ export const Navbar: React.FC<NavbarProps> = ({
               arrowItems={params.topicMap?.arrowItems ?? []}
               backgroundImage={params.topicMap?.gridBackgroundImage}
               grid={params.topicMap?.grid}
-              fullscreenHandle={fullscreenHandle}
             />
           </div>
           {isHamburgerOpen && (

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -99,7 +99,7 @@ export const Navbar: React.FC<NavbarProps> = ({
    * React supplies useResizeObserver hook, but H5P may trigger `resize` not
    * only when the window resizes
    */
-  instance.on('resize', () => {
+  instance.on("resize", () => {
     window.requestAnimationFrame(() => {
       if (!gridRef.current) {
         return;

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { useState } from "react";
 import type { FullScreenHandle } from "react-full-screen";
 import { useReactToPrint } from "react-to-print";
+import type { IH5PContentType } from "h5p-types";
 import { useContentId } from "../../hooks/useContentId";
 import { useH5PInstance } from "../../hooks/useH5PInstance";
 import { useL10n } from "../../hooks/useLocalization";
@@ -21,7 +22,6 @@ import styles from "./Navbar.module.scss";
 import { NotesList } from "./NotesSection/NotesList/NotesList";
 import { NotesSection } from "./NotesSection/NotesSection";
 import { H5P } from "../../h5p/H5P.util";
-import type { IH5PContentType } from "h5p-types";
 
 export type NavbarProps = {
   navbarTitle: string;
@@ -132,7 +132,7 @@ export const Navbar: React.FC<NavbarProps> = ({
         }
       }
     }
-  }, [currentSection, H5P.isFullscreen, navbarHeight]);
+  }, [currentSection, navbarHeight]);
 
   React.useEffect(() => {
     if (currentSection === NavbarSections.Notes) {
@@ -144,13 +144,7 @@ export const Navbar: React.FC<NavbarProps> = ({
         setNotesListMaxHeight(sectionMaxHeight - notesSectionHeight);
       }
     }
-  }, [
-    currentSection,
-    H5P.isFullscreen,
-    navbarHeight,
-    notesSectionHeight,
-    sectionMaxHeight,
-  ]);
+  }, [currentSection, navbarHeight, notesSectionHeight, sectionMaxHeight]);
 
   React.useEffect(() => {
     const newProgressBarValue = allItems.filter(

--- a/src/h5p/H5PWrapper.tsx
+++ b/src/h5p/H5PWrapper.tsx
@@ -19,7 +19,7 @@ import {
 } from "./H5P.util";
 
 export class H5PWrapper extends H5P.EventDispatcher implements IH5PContentType {
-  public containerElement: HTMLElement|undefined;
+  public containerElement: HTMLElement | undefined;
 
   private wrapper: HTMLElement;
 
@@ -85,28 +85,31 @@ export class H5PWrapper extends H5P.EventDispatcher implements IH5PContentType {
     const l10n = params.l10n ?? ({} as Translations);
     const title = extras?.metadata.title;
 
-    this.on('enterFullScreen', () => {
+    this.on("enterFullScreen", () => {
       setTimeout(() => {
-        this.trigger('resize');
+        this.trigger("resize");
       }, 250); // DOM might need time to change size
     });
 
-    this.on('exitFullScreen', () => {
+    this.on("exitFullScreen", () => {
       setTimeout(() => {
-        this.trigger('resize');
+        this.trigger("resize");
       }, 250); // DOM might need time to change size
     });
 
     // React components require 'resize' once H5P container attached to DOM
-    this.observer = new IntersectionObserver(entries => {
-      if (entries[0].intersectionRatio === 1) {
-        this.observer.unobserve(this.containerElement as Element); // Only need instantiate once.
-        this.trigger('resize');
-      }
-    }, {
-      root: document.documentElement,
-      threshold: [1]
-    });
+    this.observer = new IntersectionObserver(
+      entries => {
+        if (entries[0].intersectionRatio === 1) {
+          this.observer.unobserve(this.containerElement as Element); // Only need instantiate once.
+          this.trigger("resize");
+        }
+      },
+      {
+        root: document.documentElement,
+        threshold: [1],
+      },
+    );
 
     render(
       <ContentIdContext.Provider value={contentId}>
@@ -129,32 +132,30 @@ export class H5PWrapper extends H5P.EventDispatcher implements IH5PContentType {
    * Toggle fullscreen button.
    * @param {string|boolean} state enter|false for enter, exit|true for exit.
    */
-  handleToggleFullscreen(state?: string|boolean): void {
+  handleToggleFullscreen(state?: string | boolean): void {
     if (!this.containerElement) {
       return;
     }
 
-    let newState: boolean|undefined;
-    if (typeof state === 'string') {
-      if (state === 'enter') {
+    let newState: boolean | undefined;
+    if (typeof state === "string") {
+      if (state === "enter") {
         newState = false;
-      }
-      else if (state === 'exit') {
+      } else if (state === "exit") {
         newState = true;
       }
     }
 
-    if (typeof newState !== 'boolean') {
+    if (typeof newState !== "boolean") {
       newState = !H5P.isFullscreen;
     }
 
     if (newState === true) {
       H5P.fullScreen(H5P.jQuery(this.containerElement), this);
-    }
-    else {
+    } else {
       H5P.exitFullScreen();
     }
-  };
+  }
 
   attach($container: JQuery<HTMLElement>): void {
     this.containerElement = $container.get(0);
@@ -168,7 +169,7 @@ export class H5PWrapper extends H5P.EventDispatcher implements IH5PContentType {
     this.containerElement.appendChild(this.wrapper);
     this.containerElement.classList.add("h5p-topic-map");
 
-    this.observer.observe(this.containerElement as Element);    
+    this.observer.observe(this.containerElement as Element);
   }
 
   private static createWrapperElement(): HTMLDivElement {


### PR DESCRIPTION
When merged in, will replace the custom react resize observer with listening to `resize` events triggered on the H5P content type instance.

While the custom resize observer would detect changes in the window size, H5P or parents of compound content types may also trigger `resize` events for other occasions that would go unnoticed otherwise.